### PR TITLE
Add Dockerfile and Docker Makefile targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.pytest_cache
+.ruff_cache
+__pycache__
+*.egg-info
+dist
+build
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+COPY pyproject.toml uv.lock* ./
+RUN uv sync --frozen 2>/dev/null || uv sync
+
+COPY pyquickref/ pyquickref/
+COPY tests/ tests/
+COPY Makefile ./
+
+CMD ["uv", "run", "pyquickref"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help lint format format-check typecheck test check all clean run list
+.PHONY: help lint format format-check typecheck test check all clean run list \
+       docker-build docker-check docker-test docker-lint docker-format docker-run docker-list
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -32,3 +33,26 @@ list: ## List all examples with doc links
 clean: ## Remove build artifacts
 	rm -rf build/ dist/ *.egg-info .pytest_cache .ruff_cache __pycache__
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+
+IMAGE := pyquickref
+
+docker-build: ## Build Docker image
+	docker build -t $(IMAGE) .
+
+docker-check: docker-build ## Run all checks in Docker
+	docker run --rm $(IMAGE) make check
+
+docker-test: docker-build ## Run tests in Docker
+	docker run --rm $(IMAGE) make test
+
+docker-lint: docker-build ## Run linting in Docker
+	docker run --rm $(IMAGE) make lint
+
+docker-format: docker-build ## Run formatting in Docker
+	docker run --rm $(IMAGE) make format
+
+docker-run: docker-build ## Run all examples in Docker
+	docker run --rm $(IMAGE)
+
+docker-list: docker-build ## List all examples in Docker
+	docker run --rm $(IMAGE) uv run pyquickref --list

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ make run             # run all examples
 make list            # list all examples
 ```
 
+### Docker (no local tooling needed)
+
+```bash
+make docker-check    # run all checks in a container
+make docker-run      # run all examples in a container
+make docker-list     # list all examples in a container
+make docker-test     # run tests only
+make docker-lint     # run linting only
+```
+
 Or run individual tools directly:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add Dockerfile with uv and dev tools (ruff, ty, pytest) for running without local tooling
- Add `.dockerignore` to keep image lean
- Add Docker Makefile targets: `docker-build`, `docker-check`, `docker-test`, `docker-lint`, `docker-format`, `docker-run`, `docker-list`
- Update README with Docker usage section

## Test plan
- [x] `make docker-check` passes (all 65 tests, lint, format, typecheck)
- [x] `make docker-run` runs all examples